### PR TITLE
top-p implementation & loss output simplification

### DIFF
--- a/balm/config/balm_moe_config.py
+++ b/balm/config/balm_moe_config.py
@@ -81,7 +81,9 @@ class BalmMoEConfig(PretrainedConfig):
     use_p_penalty_loss: bool, default=False
         Whether or not to use p-penalty loss instead of standard aux loss.
     router_penalty_loss_coef: float, default=0.01
-        The coefficient for the p-penalty loss.
+        The coefficient for the p-penalty loss for heterogeneous sized experts.
+    router_dynamic_loss_coef: float, default=0.0001
+        The coeeficient for the dynamic loss for top-p models.
     expert_capacity_type: str, default="multiplier"
         The type of expert capacity to use.
         If "absolute": tokens per expert; if "multiplier": capacity = multiplier * max_position_embeddings
@@ -201,6 +203,7 @@ class BalmMoEConfig(PretrainedConfig):
         router_z_loss_coef: float = 0.001,
         router_use_penalty_loss: bool = False,
         router_penalty_loss_coef: float = 0.1,
+        router_dynamic_loss_coef: float = 0.0001,
         # experts
         expert_capacity_type: str = "multiplier",
         expert_capacity: int = 1,
@@ -267,6 +270,7 @@ class BalmMoEConfig(PretrainedConfig):
         self.router_z_loss_coef = float(router_z_loss_coef)
         self.router_use_penalty_loss = bool(router_use_penalty_loss)
         self.router_penalty_loss_coef = float(router_penalty_loss_coef)
+        self.router_dynamic_loss_coef = float(router_dynamic_loss_coef)
         self.expert_capacity_type = expert_capacity_type.lower()
         self.expert_capacity = expert_capacity
         self.expert_intermediate_size = self._get_expert_sizes(

--- a/balm/config/balm_moe_config.py
+++ b/balm/config/balm_moe_config.py
@@ -58,6 +58,8 @@ class BalmMoEConfig(PretrainedConfig):
         The number of shared experts (which receive all tokens) in the model.
     num_experts_per_tok : int, default=1
         The number of experts to route each token to. Only used if `router_type` is "top-k".
+    top_p_threshold: float, default=0.5
+        The probability threshold for "top-p" routing. Only used if `router_type` is "top-p".
     num_initial_dense_layers: int, default=1
         The number of dense layers at the start of the model before any sparse layers.
     alternate_sparsity : bool, default=True
@@ -185,6 +187,7 @@ class BalmMoEConfig(PretrainedConfig):
         num_experts: int = 8,
         num_shared_experts: int = 0,
         num_experts_per_tok: int = 1,  # k for top-k routing (to comply with 🤗 naming)
+        top_p_threshold: float = 0.5,
         num_initial_dense_layers: int = 1,
         alternate_sparsity: bool = True,
         # router
@@ -252,6 +255,7 @@ class BalmMoEConfig(PretrainedConfig):
         self.num_experts = int(num_experts)
         self.num_shared_experts = int(num_shared_experts)
         self.num_experts_per_tok = int(num_experts_per_tok)
+        self.top_p_threshold = float(top_p_threshold)
         self.num_initial_dense_layers = int(num_initial_dense_layers)
         self.alternate_sparsity = bool(alternate_sparsity)
         self.router_type = self._standardize_router_type(router_type)
@@ -384,7 +388,9 @@ class BalmMoEConfig(PretrainedConfig):
                 raise ValueError(
                     "All elements of expert_intermediate_size must be integers."
                 )
-            if (self.router_type == "expert-choice") and (len(set(expert_intermediate_size)) > 1):
+            if (self.router_type == "expert-choice") and (
+                len(set(expert_intermediate_size)) > 1
+            ):
                 raise ValueError(
                     "Heterogeneous expert sizes are not compatible with the expert choice router."
                 )

--- a/balm/config/balm_moe_config.py
+++ b/balm/config/balm_moe_config.py
@@ -4,7 +4,6 @@
 
 from typing import Optional, Union, List
 
-import torch
 from transformers import PretrainedConfig
 
 

--- a/balm/config/balm_moe_config.py
+++ b/balm/config/balm_moe_config.py
@@ -382,7 +382,7 @@ class BalmMoEConfig(PretrainedConfig):
                 raise ValueError(
                     "All elements of expert_intermediate_size must be integers."
                 )
-            if self.router_type == "expert choice":
+            if (self.router_type == "expert-choice") and (len(set(expert_intermediate_size)) > 1):
                 raise ValueError(
                     "Heterogeneous expert sizes are not compatible with the expert choice router."
                 )

--- a/balm/loss.py
+++ b/balm/loss.py
@@ -177,7 +177,7 @@ def router_p_penalty_loss(
     # normalize expert hidden sizes such that the p penalty loss
     # reduces to aux loss when all experts are the same size
     expert_hidden_sizes = torch.tensor(expert_hidden_sizes, device=device)
-    normalized_dims = expert_hidden_sizes / expert_hidden_sizes.min()
+    normalized_dims = expert_hidden_sizes / expert_hidden_sizes.max()
     penalty = tokens_per_expert * normalized_dims
 
     # avg probability of routing to each experts ==> (num_experts)

--- a/balm/loss.py
+++ b/balm/loss.py
@@ -6,7 +6,12 @@ from typing import Optional, List
 
 import torch
 
-__all__ = ["router_z_loss", "router_load_balancing_loss", "router_p_penalty_loss"]
+__all__ = [
+    "router_z_loss",
+    "router_load_balancing_loss",
+    "router_p_penalty_loss",
+    "router_dynamic_loss",
+]
 
 
 def router_z_loss(router_logits: torch.Tensor) -> torch.Tensor:
@@ -136,7 +141,8 @@ def router_p_penalty_loss(
     router_probs: torch.Tensor, k: int, expert_hidden_sizes: List
 ) -> torch.Tensor:
     """
-    Computes the parameter penalty (P-Penalty) loss.
+    Computes the parameter penalty (P-Penalty) loss for heterogeneous
+    size experts
 
     See the `HMoE paper`_ for more details.
 
@@ -211,9 +217,5 @@ def router_dynamic_loss(
     .. _Dynamic Routing paper:
         https://arxiv.org/abs/2403.07652
     """
-
     loss = -torch.sum(router_probs * torch.log(router_probs), dim=-1)
-    print(loss)
-    raise Exception()
-
     return loss.mean()

--- a/balm/loss.py
+++ b/balm/loss.py
@@ -7,10 +7,18 @@ from typing import Optional, List
 import torch
 
 __all__ = [
+    "ROUTER_LOSSES",
     "router_z_loss",
     "router_load_balancing_loss",
     "router_p_penalty_loss",
     "router_dynamic_loss",
+]
+
+ROUTER_LOSSES = [
+    "z_loss",
+    "aux_loss",
+    "penalty_loss",
+    "dynamic_loss",
 ]
 
 

--- a/balm/models/balm_moe.py
+++ b/balm/models/balm_moe.py
@@ -633,7 +633,7 @@ class BalmMoEForSequenceClassification(
             if self.config.router_type == "expert choice":
                 z_loss = self.router_z_loss_coef * (outputs.z_loss)
                 loss = classifier_loss + z_loss
-            elif self.config.router_use_penalty_loss:
+            elif self.config.homogeneous_experts:
                 aux_loss = self.router_aux_loss_coef * (outputs.aux_loss)
                 z_loss = self.router_z_loss_coef * (outputs.z_loss)
                 loss = classifier_loss + z_loss + aux_loss

--- a/balm/models/base.py
+++ b/balm/models/base.py
@@ -2,16 +2,13 @@
 # Distributed under the terms of the MIT License.
 # SPDX-License-Identifier: MIT
 
-import json
-import os
-import re
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Optional
 
-import torch
 import torch.nn as nn
 from transformers import PreTrainedModel
 
 from ..modules import SparseFFN
+from ..loss import ROUTER_LOSSES
 
 WEIGHTS_NAME = "model.pt"
 SAFE_WEIGHTS_NAME = "model.safetensors"
@@ -27,6 +24,19 @@ class BalmPreTrainedModel(PreTrainedModel):
     """
 
     supports_gradient_checkpointing = True
+
+    def __init__(self, config, *args, **kwargs):
+        super().__init__(config, *args, **kwargs)
+
+        # router loss coefficients
+        # extract values as a dict, so that we can zero them out in freeze_base_model()
+        # and access them when calculating the loss
+        if self.base_model_prefix == "balm_moe":
+            self.router_loss_coeffs = {
+                k: getattr(config, f"router_{k}_coef")
+                for k in ROUTER_LOSSES
+                if hasattr(config, f"router_{k}_coef")
+            }
 
     # Copied from transformers.models.bert.modeling_bert.BertPreTrainedModel._init_weights
     def _init_weights(self, module):
@@ -71,14 +81,9 @@ class FreezeBaseModelMixin:
             param.requires_grad = False
 
         # zero out router loss coefficients (MoE models only)
-        if hasattr(self, "router_z_loss_coef"):
-            self.router_z_loss_coef = 0.0
-        if hasattr(self, "router_aux_loss_coef"):
-            self.router_aux_loss_coef = 0.0
-        if hasattr(self, "router_penalty_loss_coef"):
-            self.router_penalty_loss_coef = 0.0
-        if hasattr(self, "router_dynamic_loss_coef"):
-            self.router_dynamic_loss_coef = 0.0
+        if hasattr(self, "router_loss_coeffs"):
+            for k in self.router_loss_coeffs:
+                self.router_loss_coeffs[k] = 0.0
 
 
 class ParameterCountMixin:
@@ -189,9 +194,7 @@ class ParameterCountMixin:
                     total_num_params += shared_expert_params
 
                 # experts (partially active)
-                total_expert_params = sum(
-                    p.numel() for p in moe.experts.parameters()
-                )
+                total_expert_params = sum(p.numel() for p in moe.experts.parameters())
                 active_expert_params = total_expert_params * prop_tokens_per_expert
                 total_num_params += active_expert_params
         # count all parameters

--- a/balm/models/base.py
+++ b/balm/models/base.py
@@ -77,6 +77,8 @@ class FreezeBaseModelMixin:
             self.router_aux_loss_coef = 0.0
         if hasattr(self, "router_penalty_loss_coef"):
             self.router_penalty_loss_coef = 0.0
+        if hasattr(self, "router_dynamic_loss_coef"):
+            self.router_dynamic_loss_coef = 0.0
 
 
 class ParameterCountMixin:

--- a/balm/modules.py
+++ b/balm/modules.py
@@ -2,7 +2,6 @@
 # Distributed under the terms of the MIT License.
 # SPDX-License-Identifier: MIT
 
-from functools import partial
 from typing import Optional, Tuple, Union, List
 
 import torch

--- a/balm/outputs.py
+++ b/balm/outputs.py
@@ -4,7 +4,7 @@
 
 
 from dataclasses import dataclass
-from typing import Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
 import torch
 from transformers.utils.generic import ModelOutput
@@ -127,10 +127,9 @@ class MoEModelOutput(BalmModelOutput):
         The router logits tensor. The shape is (batch_size, sequence_length, num_experts).
     expert_indexes : Optional[Tuple[torch.LongTensor]]
         The expert indexes tensor. The shape is (batch_size, sequence_length, num_experts).
-    z_loss : torch.FloatTensor
-        The z loss tensor. The shape is (1,).
-    aux_loss : torch.FloatTensor
-        The auxiliary loss tensor. The shape is (1,).
+    moe_losses : Optional[Dict[torch.FloatTensor]]
+        A dict containing the MoE losses. Can include any of the following losses:
+        aux_loss, penalty_loss, z_loss, dynamic_loss
     """
 
     last_hidden_state: torch.FloatTensor = None
@@ -138,9 +137,7 @@ class MoEModelOutput(BalmModelOutput):
     attentions: Optional[Tuple[torch.FloatTensor, ...]] = None
     router_logits: Optional[Tuple[torch.FloatTensor]] = None
     expert_indexes: Optional[Tuple[torch.LongTensor]] = None
-    z_loss: torch.FloatTensor = None
-    aux_loss: torch.FloatTensor = None
-    penalty_loss: torch.FloatTensor = None
+    moe_losses: Optional[Dict[str, torch.FloatTensor]] = None
 
 
 @dataclass
@@ -162,12 +159,9 @@ class MoEMaskedLMOutput(BalmModelOutput):
         The router logits tensor. The shape is (batch_size, sequence_length, num_experts).
     expert_indexes : Optional[Tuple[torch.LongTensor]]
         The expert indexes tensor. The shape is (batch_size, sequence_length, num_experts).
-    z_loss : torch.FloatTensor
-        The z loss tensor. The shape is (1,).
-    aux_loss : torch.FloatTensor
-        The auxiliary loss tensor. The shape is (1,).
-    lm_loss : torch.FloatTensor
-        The masked language model loss tensor. The shape is (1,).
+    moe_losses : Optional[Dict[torch.FloatTensor]]
+        A dict containing the MoE losses. Can include any of the following losses:
+        lm_loss, aux_loss, penalty_loss, z_loss, dynamic_loss
     """
 
     loss: Optional[torch.FloatTensor] = None
@@ -176,10 +170,7 @@ class MoEMaskedLMOutput(BalmModelOutput):
     attentions: Optional[Tuple[torch.FloatTensor, ...]] = None
     router_logits: Optional[Tuple[torch.FloatTensor]] = None
     expert_indexes: Optional[Tuple[torch.LongTensor]] = None
-    z_loss: torch.FloatTensor = None
-    aux_loss: torch.FloatTensor = None
-    penalty_loss: torch.FloatTensor = None
-    lm_loss: torch.FloatTensor = None
+    moe_losses: Optional[Dict[str, torch.FloatTensor]] = None
 
 
 @dataclass
@@ -203,12 +194,9 @@ class MoESequenceClassifierOutput(BalmModelOutput):
         The expert indexes tensor. The shape is (batch_size, sequence_length, num_experts).
     classifier_attentions : Optional[Tuple[torch.FloatTensor, ...]]
         The classifier attention weights tensor. The shape is (batch_size, num_heads, sequence_length, sequence_length).
-    z_loss : torch.FloatTensor
-        The z loss tensor. The shape is (1,).
-    aux_loss : torch.FloatTensor
-        The auxiliary loss tensor. The shape is (1,).
-    classifier_loss : torch.FloatTensor
-        The classifier loss tensor. The shape is (1,).
+    moe_losses : Optional[Dict[torch.FloatTensor]]
+        A dict containing the MoE losses. Can include any of the following losses:
+        classifier_loss, aux_loss, penalty_loss, z_loss, dynamic_loss
     """
 
     loss: Optional[torch.FloatTensor] = None
@@ -218,7 +206,4 @@ class MoESequenceClassifierOutput(BalmModelOutput):
     router_logits: Optional[Tuple[torch.FloatTensor]] = None
     expert_indexes: Optional[Tuple[torch.LongTensor]] = None
     classifier_attentions: Optional[torch.FloatTensor] = None
-    z_loss: torch.FloatTensor = None
-    aux_loss: torch.FloatTensor = None
-    penalty_loss: torch.FloatTensor = None
-    classifier_loss: torch.FloatTensor = None
+    moe_losses: Optional[Dict[str, torch.FloatTensor]] = None

--- a/balm/router.py
+++ b/balm/router.py
@@ -33,8 +33,10 @@ class BaseRouter(nn.Module):
         num_experts: int,
         router_bias: bool,
         router_dtype: str,
+        **kwargs,
     ):
         super().__init__()
+        self.num_experts = num_experts
         self.router_dtype = self._str_to_dtype(router_dtype)
         self.linear = nn.Linear(d_model, num_experts, bias=router_bias)
 
@@ -52,15 +54,77 @@ class BaseRouter(nn.Module):
 
         return dtype_mapping[dtype_str]
 
+    def _assign_tokens_to_experts(
+        self,
+        flat_expert_ids: torch.Tensor,
+        flat_token_ids: torch.Tensor,
+        flat_probs: torch.Tensor,
+        flat_unnorm_probs: torch.Tensor,
+        num_tokens: int,
+        expert_capacity: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Assigns tokens to experts based on top-k or top-p routing outputs.
+
+        Returns:
+        --------
+        expert_probs : torch.Tensor
+            Tensor of shape (num_experts, expert_capacity) containing the selected normalized probabilities.
+        expert_indices : torch.Tensor
+            Tensor of shape (num_experts, expert_capacity) containing token indices assigned to each expert.
+        """
+        # handle no expert capacity
+        # max number of tokens one expert could take is the num_tokens
+        if expert_capacity == -1:
+            expert_capacity = num_tokens
+
+        # initalize empty tensors for results
+        expert_probs = torch.zeros(
+            (self.num_experts, expert_capacity), dtype=dtype, device=device
+        )
+        expert_indices = torch.full(
+            (self.num_experts, expert_capacity),
+            fill_value=-1,
+            dtype=torch.long,
+            device=device,
+        )
+
+        # for each expert, pick up to 'expert_capacity' tokens in order of highest expert affinity
+        # loop over experts, grouping slots that picked each expert
+        for e in range(self.num_experts):
+            # select token_ids and probs for expert e only
+            mask = flat_expert_ids == e
+            chosen_token_ids = flat_token_ids[mask]
+            chosen_unnorm_probs = flat_unnorm_probs[mask]
+            chosen_probs = flat_probs[mask]
+
+            num_chosen_tokens = chosen_token_ids.numel()
+
+            # sort by expert affinity
+            if num_chosen_tokens > 0:
+
+                # keep highest unnormalized probs, up to `expert_capacity` tokens per expert
+                keep = min(expert_capacity, num_chosen_tokens)
+                _, sorted_idx = torch.topk(chosen_unnorm_probs, keep, sorted=False)
+
+                # filter for selected idxs
+                expert_probs[e, :keep] = chosen_probs[
+                    sorted_idx
+                ]  # use normalized probs for weighting expert outputs
+                expert_indices[e, :keep] = chosen_token_ids[sorted_idx]
+
+        return expert_probs, expert_indices
+
 
 class TopKRouter(BaseRouter):
     """
-    Router that implements the "token choice of top-k experts" strategy. For example, if k=1, this
-    replicates the top-1 routing strategy introduced in the `Switch Transformers`_ paper.
-    Alternatively, if k=2, this replicates the top-2 routing strategy introduced in the `GShard`_
-    paper. Tokens are routed to their expert of choice until the expert's `expert_capacity` is
-    reached. Shared experts, which process all tokens, are implemented as described in the
-    `DeepSeqMoE`_ paper.
+    Router that implements the "token choice of top-k experts" strategy.
+
+    If k=1, this matches the `Switch Transformers`_ top-1 routing.
+    If k=2, it matches the `GShard`_ top-2 strategy.
+    Shared expert routing is handled as in `DeepSeqMoE`_.
 
     .. note::
         There is no guarantee that each token will be processed by an expert,
@@ -81,14 +145,29 @@ class TopKRouter(BaseRouter):
 
     """
 
-    def forward(self, x: torch.Tensor, k: int, expert_capacity: int):
+    def __init__(
+        self,
+        d_model: int,
+        num_experts: int,
+        router_bias: bool,
+        router_dtype: str,
+        k: int,
+        **kwargs,
+    ):
+        self.k = k
+        super().__init__(
+            d_model=d_model,
+            num_experts=num_experts,
+            router_bias=router_bias,
+            router_dtype=router_dtype,
+        )
+
+    def forward(self, x: torch.Tensor, expert_capacity: int):
         """
         Parameters:
         -----------
         x : torch.Tensor
             Shape: `(num_tokens, d_model)`. Input token representations.
-        k : int
-            Maximum number of experts each token can choose.
         expert_capacity : int
             Maximum number of tokens each expert can process.
 
@@ -105,13 +184,7 @@ class TopKRouter(BaseRouter):
         """
 
         num_tokens = x.size(0)
-        num_experts = self.linear.out_features
-        k = min(k, num_experts)
-
-        # handle no expert capacity
-        # max number of tokens one expert could take is the num_tokens
-        if expert_capacity == -1:
-            expert_capacity = num_tokens
+        k = min(self.k, self.num_experts)
 
         # compute routing logits and probs ==> (num_tokens, num_experts)
         logits = self.linear(x)
@@ -141,40 +214,17 @@ class TopKRouter(BaseRouter):
         # in flattened form: e.g. 0..(num_tokens-1) repeated k times ==> (num_tokens * k)
         flat_token_ids = torch.arange(num_tokens * k, device=x.device) // k
 
-        # initalize empty tensors for results
-        expert_probs = torch.zeros(
-            (num_experts, expert_capacity), dtype=probs.dtype, device=probs.device
-        )
-        expert_indices = torch.full(
-            (num_experts, expert_capacity),
-            fill_value=-1,
-            dtype=torch.long,
+        # reshape indices and probs
+        expert_probs, expert_indices = self._assign_tokens_to_experts(
+            flat_expert_ids=flat_expert_ids,
+            flat_token_ids=flat_token_ids,
+            flat_probs=flat_probs,
+            flat_unnorm_probs=flat_unnorm_probs,
+            num_tokens=num_tokens,
+            expert_capacity=expert_capacity,
             device=probs.device,
+            dtype=probs.dtype,
         )
-
-        # for each expert, pick up to 'expert_capacity' tokens in order of highest expert affinity
-        # loop over experts, grouping slots that picked each expert
-        for e in range(num_experts):
-            # select token_ids and probs for expert e only
-            mask = flat_expert_ids == e
-            chosen_token_ids = flat_token_ids[mask]
-            chosen_unnorm_probs = flat_unnorm_probs[mask]
-            chosen_probs = flat_probs[mask]
-
-            num_chosen_tokens = chosen_token_ids.numel()
-
-            # sort by expert affinity
-            if num_chosen_tokens > 0:
-
-                # keep highest unnormalized probs, up to `expert_capacity` tokens per expert
-                keep = min(expert_capacity, num_chosen_tokens)
-                _, sorted_idx = torch.topk(chosen_unnorm_probs, keep, sorted=False)
-
-                # filter for selected idxs
-                expert_probs[e, :keep] = chosen_probs[
-                    sorted_idx
-                ]  # use normalized probs for weighting expert outputs
-                expert_indices[e, :keep] = chosen_token_ids[sorted_idx]
 
         return logits, probs, expert_probs, expert_indices
 
@@ -197,7 +247,8 @@ class TopPRouter(BaseRouter):
         num_experts: int,
         router_bias: bool,
         router_dtype: str,
-        top_p_threshold: Optional[float] = 0.7,
+        top_p_threshold: float,
+        **kwargs,
     ):
         self.threshold = top_p_threshold
         super().__init__(
@@ -207,14 +258,12 @@ class TopPRouter(BaseRouter):
             router_dtype=router_dtype,
         )
 
-    def forward(self, x: torch.Tensor, k: int, expert_capacity: int):
+    def forward(self, x: torch.Tensor, expert_capacity: int):
         """
         Parameters:
         -----------
         x : torch.Tensor
             Shape: `(num_tokens, d_model)`. Input token representations.
-        k : int
-            Maximum number of experts each token can choose.
         expert_capacity : int
             Maximum number of tokens each expert can process.
 
@@ -231,10 +280,6 @@ class TopPRouter(BaseRouter):
         """
 
         num_tokens = x.size(0)
-        num_experts = self.linear.out_features
-        k = min(k, num_experts)
-
-        torch.set_printoptions(profile="full")
 
         # compute routing logits and probs ==> (num_tokens, num_experts)
         logits = self.linear(x)
@@ -247,23 +292,31 @@ class TopPRouter(BaseRouter):
 
         # cumulative probs
         cumulative_probs = torch.cumsum(sorted_probs, dim=-1)
-        mask = cumulative_probs > self.threshold
 
-        # find threshold indices
-        threshold_indices = mask.long().argmax(dim=-1)
-        threshold_mask = torch.nn.functional.one_hot(
-            threshold_indices, num_classes=sorted_indices.size(-1)
-        ).bool()
+        # mask
+        mask = cumulative_probs <= self.threshold
+        mask[..., 0] = (
+            1  # always keep the first expert (accounts for tokens where highest prob is > threshold)
+        )
 
-        # apply masks ==> (num_tokens, num_experts)
-        mask = mask & ~threshold_mask
-        sorted_indices = torch.where(mask, -1, sorted_indices)
-        sorted_probs = torch.where(mask, 0.0, sorted_probs)
+        # apply mask
+        selected_expert_ids = sorted_indices[mask]
+        selected_probs = sorted_probs[mask]
+        selected_token_ids = torch.nonzero(mask, as_tuple=True)[0]
 
         # reshape indices and probs
-        raise Exception()
+        expert_probs, expert_indices = self._assign_tokens_to_experts(
+            flat_expert_ids=selected_expert_ids,
+            flat_token_ids=selected_token_ids,
+            flat_probs=selected_probs,
+            flat_unnorm_probs=selected_probs,
+            num_tokens=num_tokens,
+            expert_capacity=expert_capacity,
+            device=probs.device,
+            dtype=probs.dtype,
+        )
 
-        return logits, probs, sorted_probs, sorted_indices
+        return logits, probs, expert_probs, expert_indices
 
 
 class ExpertChoiceRouter(BaseRouter):
@@ -287,9 +340,7 @@ class ExpertChoiceRouter(BaseRouter):
 
     """
 
-    def forward(
-        self, x: torch.Tensor, expert_capacity: int, **kwargs
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    def forward(self, x: torch.Tensor, expert_capacity: int):
         """
         Parameters:
         -----------

--- a/balm/router.py
+++ b/balm/router.py
@@ -2,7 +2,7 @@
 # Distributed under the terms of the MIT License.
 # SPDX-License-Identifier: MIT
 
-from typing import Optional, Tuple
+from typing import Tuple
 
 import torch
 import torch.nn as nn

--- a/balm/trainer.py
+++ b/balm/trainer.py
@@ -28,9 +28,9 @@ __all__ = ["MoETrainer"]
 
 
 loss_mapping = {
-    "topk": ["lm_loss", "aux_loss", "z_loss"],
-    "topk-penalty": ["lm_loss", "penalty_loss"],
-    "topk-aux": ["lm_loss", "aux_loss"],
+    "top-k": ["lm_loss", "aux_loss", "z_loss"],
+    "top-k-penalty": ["lm_loss", "penalty_loss"],
+    "top-k-aux": ["lm_loss", "aux_loss"],
     "expert choice": ["lm_loss", "z_loss"],
 }
 

--- a/balm/trainer.py
+++ b/balm/trainer.py
@@ -29,9 +29,12 @@ __all__ = ["MoETrainer"]
 
 loss_mapping = {
     "top-k": ["lm_loss", "aux_loss", "z_loss"],
+    "top-p": ["lm_loss", "aux_loss", "z_loss"],
     "top-k-penalty": ["lm_loss", "penalty_loss"],
     "top-k-aux": ["lm_loss", "aux_loss"],
-    "expert choice": ["lm_loss", "z_loss"],
+    "top-p-penalty": ["lm_loss", "penalty_loss"],
+    "top-p-aux": ["lm_loss", "aux_loss"],
+    "expert-choice": ["lm_loss", "z_loss"],
 }
 
 


### PR DESCRIPTION
- **fix: moe classification loss**
- **fix: check for heterogenous experts in expert choice models**
- **feat (wip): incomplete implementation of top-p routing**
- **feat: normalize penalty loss by largest expert**
- **fix: top-k mapping in trainer**
- **feat: top-p implementation (using top-1 for aux loss calculations)**
- **feat: implement dynamic loss for top-p & modify moe loss components to output as a single dict**
- **fix: scale moe losses by coeff in output & simplify loss coeff tracking**
- **chore: remove unused imports**
