### PR TITLE
Mixed data and attention classifier bug fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "numpy",
     "pandas",
     "polars",
-    "transformers",
+    "transformers<4.51.0",
     "tokenizers",
     "torch",
     "tqdm"

--- a/src/balm/config/balm_moe_config.py
+++ b/src/balm/config/balm_moe_config.py
@@ -56,7 +56,7 @@ class BalmMoEConfig(PretrainedConfig):
         The number of shared experts (which receive all tokens) in the model.
     num_experts_per_tok : int, default=1
         The number of experts to route each token to. Only used if `router_type` is "top-k".
-    top_p_threshold: float, default=0.5
+    top_p_threshold: float, default=0.7
         The probability threshold for "top-p" routing. Only used if `router_type` is "top-p".
     num_initial_dense_layers: int, default=1
         The number of dense layers at the start of the model before any sparse layers.
@@ -186,7 +186,7 @@ class BalmMoEConfig(PretrainedConfig):
         num_experts: int = 8,
         num_shared_experts: int = 0,
         num_experts_per_tok: int = 1,  # k for top-k routing (to comply with 🤗 naming)
-        top_p_threshold: float = 0.5,
+        top_p_threshold: float = 0.7,  # threshold for top-p routing
         num_initial_dense_layers: int = 1,
         alternate_sparsity: bool = True,
         # router

--- a/src/balm/datasets/mixed_dataset.py
+++ b/src/balm/datasets/mixed_dataset.py
@@ -109,7 +109,7 @@ def process_mixed_dataset(
     curriculum_prob: bool = None,
     seed=42,
     num_proc=128,
-    cache_dir="~/.cache/huggingface/datasets",
+    cache_dir="./.cache/",
 ):
 
     # check dict for keys

--- a/src/balm/models/balm_moe.py
+++ b/src/balm/models/balm_moe.py
@@ -326,6 +326,7 @@ class BalmMoEForMaskedLM(
 
         # initialize weights
         self.init_weights()
+        self.post_init()
 
     def forward(
         self,
@@ -501,6 +502,7 @@ class BalmMoEForSequenceClassification(
 
         # initialize weights
         self.init_weights()
+        self.post_init()
 
         # freeze base model weights
         # and zero out router loss coeffs

--- a/src/balm/modules/heads.py
+++ b/src/balm/modules/heads.py
@@ -141,8 +141,8 @@ class BalmAttentionSequenceClassificationHead(nn.Module):
     def forward(
         self,
         features: torch.Tensor,
-        padding_mask: torch.Tensor,
-        need_weights: bool,
+        padding_mask: torch.Tensor = None,
+        need_weights: bool = False,
         **kwargs,
     ) -> torch.Tensor:
         """


### PR DESCRIPTION
- fix: change default top p threshold
- fix: mixed dataset cache dir default
- upgrade: fix mixed data logging in newer accelerate versions
- fix: add post_init call to LM and SequenceClassification init fns, inline with HuggingFace ESM models
- fix: set defaults for attention sequence classifier
- feat: pin transformers version < 4.51.0
