### PR TITLE
Add pad token masking

### DIFF
--- a/src/balm/config/balm_moe_config.py
+++ b/src/balm/config/balm_moe_config.py
@@ -72,6 +72,8 @@ class BalmMoEConfig(PretrainedConfig):
         Whether to use a bias in the router.
     router_aux_loss_coef: float, default=0.01
         The coefficient for the auxiliary loss.
+    router_mask_aux_loss: bool, default=False
+        Whether to mask pad tokens in the auxiliary loss.
     router_z_loss_coef: float, default=0.001
         The coefficient for the z-loss.
     router_use_penalty_loss: bool, default=False
@@ -175,6 +177,7 @@ class BalmMoEConfig(PretrainedConfig):
         router_bias: bool = False,
         # router losses
         router_aux_loss_coef: float = 0.01,
+        router_mask_aux_loss: bool = False,
         router_z_loss_coef: float = 0.001,
         router_use_penalty_loss: bool = False,
         router_penalty_loss_coef: float = 0.1,
@@ -243,6 +246,7 @@ class BalmMoEConfig(PretrainedConfig):
         self.router_jitter = float(router_jitter)
         self.router_bias = bool(router_bias)
         self.router_aux_loss_coef = float(router_aux_loss_coef)
+        self.router_mask_aux_loss = bool(router_mask_aux_loss)
         self.router_z_loss_coef = float(router_z_loss_coef)
         self.router_use_penalty_loss = bool(router_use_penalty_loss)
         self.router_penalty_loss_coef = float(router_penalty_loss_coef)

--- a/src/balm/config/balm_moe_config.py
+++ b/src/balm/config/balm_moe_config.py
@@ -70,6 +70,8 @@ class BalmMoEConfig(PretrainedConfig):
         Jitter to apply to inputs of the router.
     router_bias: bool, default=False
         Whether to use a bias in the router.
+    router_mask_pad_logits: bool, default=False
+        Whether to mask pad tokens in the router logits.
     router_aux_loss_coef: float, default=0.01
         The coefficient for the auxiliary loss.
     router_mask_aux_loss: bool, default=False
@@ -175,6 +177,7 @@ class BalmMoEConfig(PretrainedConfig):
         router_dtype: Literal["float32", "float16", "bfloat16"] = "float32",
         router_jitter: float = 0.0,
         router_bias: bool = False,
+        router_mask_pad_logits: bool = False,
         # router losses
         router_aux_loss_coef: float = 0.01,
         router_mask_aux_loss: bool = False,
@@ -245,6 +248,7 @@ class BalmMoEConfig(PretrainedConfig):
         self.router_dtype = router_dtype.lower()
         self.router_jitter = float(router_jitter)
         self.router_bias = bool(router_bias)
+        self.router_mask_pad_logits = bool(router_mask_pad_logits)
         self.router_aux_loss_coef = float(router_aux_loss_coef)
         self.router_mask_aux_loss = bool(router_mask_aux_loss)
         self.router_z_loss_coef = float(router_z_loss_coef)

--- a/src/balm/config/balm_moe_config.py
+++ b/src/balm/config/balm_moe_config.py
@@ -71,7 +71,10 @@ class BalmMoEConfig(PretrainedConfig):
     router_bias: bool, default=False
         Whether to use a bias in the router.
     router_mask_pad_logits: bool, default=False
-        Whether to mask pad tokens in the router logits.
+        Whether to mask pad tokens in the router logits (prior to softmax).
+    router_mask_pad_probs: bool, default=False
+        Whether to mask pad tokens in the router probabilities (after softmax, prior to sorting).
+        This only applies when the `router_type` is "top-k".
     router_aux_loss_coef: float, default=0.01
         The coefficient for the auxiliary loss.
     router_mask_aux_loss: bool, default=False
@@ -178,6 +181,7 @@ class BalmMoEConfig(PretrainedConfig):
         router_jitter: float = 0.0,
         router_bias: bool = False,
         router_mask_pad_logits: bool = False,
+        router_mask_pad_probs: bool = False,
         # router losses
         router_aux_loss_coef: float = 0.01,
         router_mask_aux_loss: bool = False,
@@ -249,6 +253,7 @@ class BalmMoEConfig(PretrainedConfig):
         self.router_jitter = float(router_jitter)
         self.router_bias = bool(router_bias)
         self.router_mask_pad_logits = bool(router_mask_pad_logits)
+        self.router_mask_pad_probs = bool(router_mask_pad_probs)
         self.router_aux_loss_coef = float(router_aux_loss_coef)
         self.router_mask_aux_loss = bool(router_mask_aux_loss)
         self.router_z_loss_coef = float(router_z_loss_coef)
@@ -309,6 +314,10 @@ class BalmMoEConfig(PretrainedConfig):
         if self.expert_capacity <= 0 and self.router_type == "expert-choice":
             raise ValueError(
                 f"Invalid expert capacity: {str(self.expert_capacity)}. Expert capacity must be a positive integer for the Expert Choice router."
+            )
+        if self.router_mask_pad_probs and self.router_type != "top-k":
+            raise ValueError(
+                f"Masking pad token probabilities in the router is only compatible with the Top-K router."
             )
         # check base activations
         base_activations = ["gelu", "relu", "glu", "swiglu", "geglu", "reglu"]

--- a/src/balm/models/balm_moe.py
+++ b/src/balm/models/balm_moe.py
@@ -262,7 +262,8 @@ class BalmMoEModel(BalmPreTrainedModel, ParameterCountMixin):
                     ),
                 )
             )
-            if "aux_loss" in moe_losses:  # homogeneous experts
+            # homogeneous experts, where pad tokens aren't masked
+            if "aux_loss" in moe_losses and not self.config.router_mask_pad_logits:
                 moe_losses["z_loss"] = router_z_loss(cat_router_logits)
         else:  # top-p
             moe_losses.update(

--- a/src/balm/models/balm_moe.py
+++ b/src/balm/models/balm_moe.py
@@ -250,7 +250,7 @@ class BalmMoEModel(BalmPreTrainedModel, ParameterCountMixin):
         # router losses
         router_type = self.config.router_type
         moe_losses = {}
-        if router_type == "expert-choice":
+        if router_type == "expert-choice" and not self.config.router_mask_pad_logits:
             moe_losses["z_loss"] = router_z_loss(cat_router_logits)
         elif router_type == "top-k":
             moe_losses.update(
@@ -265,11 +265,14 @@ class BalmMoEModel(BalmPreTrainedModel, ParameterCountMixin):
             # homogeneous experts, where pad tokens aren't masked
             if "aux_loss" in moe_losses and not self.config.router_mask_pad_logits:
                 moe_losses["z_loss"] = router_z_loss(cat_router_logits)
-        else:  # top-p
+        elif router_type == "top-p":
             moe_losses.update(
                 self._get_balancing_loss(
                     cat_router_probs=cat_router_probs,
                     stack_router_probs=stack_router_probs,
+                    attention_mask=(
+                        attention_mask if self.config.router_mask_aux_loss else None
+                    ),
                 )
             )
             moe_losses["dynamic_loss"] = router_dynamic_loss(cat_router_probs)

--- a/src/balm/modules/ffn.py
+++ b/src/balm/modules/ffn.py
@@ -166,14 +166,16 @@ class SparseFFN(nn.Module):
         num_shared_experts: int,
         expert_capacity_type: str,
         expert_capacity: Union[int, float],
+        expert_activation: str,
+        expert_bias: bool,
         k: int,
         top_p_threshold: float,
-        router_type: str = "top-k",
-        router_bias: bool = False,
-        router_dtype: str = "float32",
-        router_jitter: float = 0.0,
-        expert_activation: str = "swiglu",
-        expert_bias: bool = True,
+        router_type: str,
+        router_bias: bool,
+        router_dtype: str,
+        router_jitter: float,
+        router_mask_pad_logits: bool,
+        router_mask_pad_probs: bool,
     ):
         super().__init__()
         self.num_experts = num_experts - num_shared_experts  # subtract shared experts
@@ -189,6 +191,8 @@ class SparseFFN(nn.Module):
             router_dtype=router_dtype,
             k=k,
             top_p_threshold=top_p_threshold,
+            router_mask_pad_logits=router_mask_pad_logits,
+            router_mask_pad_probs=router_mask_pad_probs,
         )
 
         # experts

--- a/src/balm/modules/layers.py
+++ b/src/balm/modules/layers.py
@@ -131,20 +131,22 @@ class SparseTransformerLayer(nn.Module):
             model_dim=config.hidden_size,
             expert_ffn_dims=config.expert_intermediate_size,
             shared_ffn_dim=config.shared_expert_intermediate_size,
-            expert_activation=config.expert_activation,
-            expert_bias=config.expert_bias,
             num_experts=config.num_experts,
             num_shared_experts=config.num_shared_experts,
             expert_capacity_type=config.expert_capacity_type,
             expert_capacity=config.expert_capacity,
+            expert_activation=config.expert_activation,
+            expert_bias=config.expert_bias,
             k=config.num_experts_per_tok,
             top_p_threshold=config.top_p_threshold,
             router_type=config.router_type,
             router_bias=config.router_bias,
             router_dtype=config.router_dtype,
             router_jitter=config.router_jitter,
+            router_mask_pad_logits=config.router_mask_pad_logits,
+            router_mask_pad_probs=config.router_mask_pad_probs,
         )
-        self.router_mask_pad_logits = config.router_mask_pad_logits
+        self.pass_attention_mask = config.router_mask_pad_logits or config.router_mask_pad_probs
         self.ffn_dropout = nn.Dropout(config.expert_dropout)
 
     def forward(
@@ -191,7 +193,7 @@ class SparseTransformerLayer(nn.Module):
         ffn_out, router_tuple = self.sparse_ffn(
             x,
             attention_mask=(
-                attention_mask if self.router_mask_pad_logits else None
+                attention_mask if self.pass_attention_mask else None
             ),
         )
         x = residual + self.ffn_dropout(ffn_out)

--- a/src/balm/modules/router.py
+++ b/src/balm/modules/router.py
@@ -33,10 +33,14 @@ class BaseRouter(nn.Module):
         num_experts: int,
         router_bias: bool,
         router_dtype: str,
+        router_mask_pad_logits: bool,
+        router_mask_pad_probs: bool,
         **kwargs,
     ):
         super().__init__()
         self.num_experts = num_experts
+        self.router_mask_pad_logits = router_mask_pad_logits
+        self.router_mask_pad_probs = router_mask_pad_probs
         self.router_dtype = self._str_to_dtype(router_dtype)
         self.linear = nn.Linear(d_model, num_experts, bias=router_bias)
 
@@ -152,6 +156,8 @@ class TopKRouter(BaseRouter):
         router_bias: bool,
         router_dtype: str,
         k: int,
+        router_mask_pad_logits: bool,
+        router_mask_pad_probs: bool,
         **kwargs,
     ):
         self.k = k
@@ -160,6 +166,8 @@ class TopKRouter(BaseRouter):
             num_experts=num_experts,
             router_bias=router_bias,
             router_dtype=router_dtype,
+            router_mask_pad_logits=router_mask_pad_logits,
+            router_mask_pad_probs=router_mask_pad_probs,
         )
 
     def forward(
@@ -196,8 +204,8 @@ class TopKRouter(BaseRouter):
         # compute routing logits and probs ==> (num_tokens, num_experts)
         logits = self.linear(x)
 
-        # mask padding tokens
-        if attention_mask is not None:
+        # mask pad tokens in logits
+        if self.router_mask_pad_logits and (attention_mask is not None):
             pad_mask = ~attention_mask.bool()
             logits[pad_mask] = float(-1e9)
 
@@ -210,9 +218,16 @@ class TopKRouter(BaseRouter):
         # convert back to original dtype
         topk_probs = topk_probs.to(x.dtype)
 
-        # normalize probs to sum to 1
-        # but save unnormalized probs for sorting
+        # save unnormalized probs for sorting
         unnorm_topk_probs = topk_probs.clone().detach()
+
+        # lower probability of padding tokens
+        # only in the unnormalized probs, for sorting only
+        if self.router_mask_pad_probs and (attention_mask is not None):
+            pad_mask = ~attention_mask.bool()
+            unnorm_topk_probs[pad_mask] = float(1e-9)
+
+        # normalize top-k probs to sum to 1
         topk_probs /= topk_probs.sum(dim=-1, keepdim=True)
 
         # flatten top-k expert IDs and probs ==> (num_tokens * k)
@@ -260,6 +275,8 @@ class TopPRouter(BaseRouter):
         router_bias: bool,
         router_dtype: str,
         top_p_threshold: float,
+        router_mask_pad_logits: bool,
+        router_mask_pad_probs: bool,
         **kwargs,
     ):
         self.threshold = top_p_threshold
@@ -268,6 +285,8 @@ class TopPRouter(BaseRouter):
             num_experts=num_experts,
             router_bias=router_bias,
             router_dtype=router_dtype,
+            router_mask_pad_logits=router_mask_pad_logits,
+            router_mask_pad_probs=router_mask_pad_probs,
         )
 
     def forward(
@@ -303,8 +322,8 @@ class TopPRouter(BaseRouter):
         # compute routing logits and probs ==> (num_tokens, num_experts)
         logits = self.linear(x)
 
-        # mask padding tokens
-        if attention_mask is not None:
+        # mask pad tokens in logits
+        if self.router_mask_pad_logits and (attention_mask is not None):
             pad_mask = ~attention_mask.bool()
             logits[pad_mask] = float(-1e9)
 
@@ -395,8 +414,8 @@ class ExpertChoiceRouter(BaseRouter):
         # compute routing logits ==> (num_tokens, num_experts)
         logits = self.linear(x)
 
-        # mask padding tokens
-        if attention_mask is not None:
+        # mask pad tokens in logits
+        if self.router_mask_pad_logits and (attention_mask is not None):
             pad_mask = ~attention_mask.bool()
             logits[pad_mask] = float(-1e9)
 

--- a/src/balm/trainer/moe.py
+++ b/src/balm/trainer/moe.py
@@ -19,6 +19,7 @@ from transformers import (
     EvalPrediction,
 )
 from packaging.version import Version
+import gc
 
 if is_torch_xla_available():
     import torch_xla.core.xla_model as xm
@@ -193,5 +194,12 @@ def compute_metrics_MoE(eval_pred: EvalPrediction):
         if isinstance(final, dict):
             for k, v in final.items():
                 metrics[k] = v.mean() if hasattr(v, "mean") else float(v)
+        
+        final.clear()
+
+    # make sure predictions are cleared from memory
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
 
     return metrics


### PR DESCRIPTION
- feat: add option to mask aux loss with attention mask
- feat: add option to mask pad tokens in router logits for topk models
- feat: add attention mask to top-p and expert choice routers
- feat: add option to mask pad token probabilities in the topk router
- fix: clear memory in compute_metrics fn
